### PR TITLE
Add command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>io.jenkins.plugins.codebuilder</groupId>
     <artifactId>codebuilder-cloud</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.2-dev</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>1.651.3</jenkins.version>

--- a/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud.java
+++ b/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud.java
@@ -54,6 +54,7 @@ import jenkins.model.JenkinsLocationConfiguration;
 public class CodeBuilderCloud extends Cloud {
   private static final Logger LOGGER = LoggerFactory.getLogger(CodeBuilderCloud.class);
   private static final String DEFAULT_JNLP_IMAGE = "lsegal/jnlp-docker-agent:alpine";
+  private static final String DEFAULT_JNLP_COMMAND = "jenkins-agent";
   private static final int DEFAULT_AGENT_TIMEOUT = 120;
   private static final String DEFAULT_COMPUTE_TYPE = "BUILD_GENERAL1_SMALL";
 
@@ -74,6 +75,7 @@ public class CodeBuilderCloud extends Cloud {
   private String computeType;
   private String jenkinsUrl;
   private String jnlpImage;
+  private String jnlpCommand;
   private int agentTimeout;
 
   private transient AWSCodeBuild client;
@@ -165,6 +167,11 @@ public class CodeBuilderCloud extends Cloud {
   @Nonnull
   public String getJnlpImage() {
     return StringUtils.isBlank(jnlpImage) ? DEFAULT_JNLP_IMAGE : jnlpImage;
+  }
+
+  @Nonnull
+  public String getJnlpCommand() {
+    return StringUtils.isBlank(jnlpCommand) ? DEFAULT_JNLP_COMMAND : jnlpCommand;
   }
 
   @DataBoundSetter
@@ -306,6 +313,9 @@ public class CodeBuilderCloud extends Cloud {
 
     public String getDefaultJnlpImage() {
       return DEFAULT_JNLP_IMAGE;
+    }
+    public String getDefaultJnlpCommand() {
+      return DEFAULT_JNLP_COMMAND;
     }
 
     public int getDefaultAgentTimeout() {

--- a/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud.java
+++ b/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud.java
@@ -179,6 +179,11 @@ public class CodeBuilderCloud extends Cloud {
     this.jnlpImage = jnlpImage;
   }
 
+  @DataBoundSetter
+  public void setJnlpCommand(String jnlpCommand) {
+    this.jnlpCommand = jnlpCommand;
+  }
+
   @Nonnull
   public int getAgentTimeout() {
     return agentTimeout == 0 ? DEFAULT_AGENT_TIMEOUT : agentTimeout;

--- a/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderLauncher.java
+++ b/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderLauncher.java
@@ -81,8 +81,8 @@ public class CodeBuilderLauncher extends JNLPLauncher {
   }
 
   private String buildspec(SlaveComputer computer) {
-    String cmd = String.format("jenkins-agent -noreconnect -workDir \"$CODEBUILD_SRC_DIR\" -url \"%s\" \"%s\" \"%s\"",
-        cloud.getJenkinsUrl(), computer.getJnlpMac(), computer.getNode().getDisplayName());
+    String cmd = String.format("%s -noreconnect -workDir \"$CODEBUILD_SRC_DIR\" -url \"%s\" \"%s\" \"%s\"",
+        cloud.getJnlpCommand(), cloud.getJenkinsUrl(), computer.getJnlpMac(), computer.getNode().getDisplayName());
     StringBuilder builder = new StringBuilder();
     builder.append("version: 0.2\n");
     builder.append("phases:\n");

--- a/src/main/resources/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud/config.jelly
+++ b/src/main/resources/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud/config.jelly
@@ -30,6 +30,10 @@
       <f:textbox />
     </f:entry>
 
+    <f:entry field="jnlpCommand" title="${%JNLP Docker Image Command}">
+      <f:textbox default="${descriptor.defaultJnlpCommand}" />
+    </f:entry>
+
     <f:entry field="jnlpImage" title="${%JNLP Docker Image}">
       <f:textbox default="${descriptor.defaultJnlpImage}" />
     </f:entry>


### PR DESCRIPTION
This is to allow to use a different jenkins-agent command, in our case, we use the jenkins-agent in our images, and rebuild all of them will take time , so have an option to use a different command will help the adoption of this plugin in our environment.