### PR TITLE
add option to change the default jenkins-agent to other name.

### DIFF
--- a/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud.java
+++ b/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud.java
@@ -57,6 +57,7 @@ import jenkins.model.JenkinsLocationConfiguration;
 public class CodeBuilderCloud extends Cloud {
   private static final Logger LOGGER = LoggerFactory.getLogger(CodeBuilderCloud.class);
   private static final String DEFAULT_JNLP_IMAGE = "lsegal/jnlp-docker-agent:alpine";
+  private static final String DEFAULT_JNLP_COMMAND = "jenkins-agent";
   private static final int DEFAULT_AGENT_TIMEOUT = 120;
   private static final String DEFAULT_COMPUTE_TYPE = "BUILD_GENERAL1_SMALL";
 
@@ -77,6 +78,7 @@ public class CodeBuilderCloud extends Cloud {
   private String computeType;
   private String jenkinsUrl;
   private String jnlpImage;
+  private String jnlpCommand;
   private int agentTimeout;
 
   private transient AWSCodeBuild client;
@@ -216,6 +218,27 @@ public class CodeBuilderCloud extends Cloud {
     }
     this.jenkinsUrl = jenkinsUrl;
   }
+
+  /**
+   * Getter for the field <code>jnlpCommand</code>.
+   *
+   * @return a {@link String} object.
+   */
+  @Nonnull
+  public String getJnlpCommand() {
+    return StringUtils.isBlank(jnlpCommand) ? DEFAULT_JNLP_COMMAND : jnlpCommand;
+  }
+
+  /**
+   * Setter for the field <code>jnlpCommand</code>.
+   *
+   * @param jnlpCommand a {@link String} object.
+   */
+  @DataBoundSetter
+  public void setJnlpCommand(String jnlpCommand) {
+    this.jnlpCommand = jnlpCommand;
+  }
+
 
   /**
    * Getter for the field <code>jnlpImage</code>.
@@ -398,6 +421,10 @@ public class CodeBuilderCloud extends Cloud {
 
     public String getDefaultJnlpImage() {
       return DEFAULT_JNLP_IMAGE;
+    }
+
+    public String getDefaultJnlpCommand() {
+      return DEFAULT_JNLP_COMMAND;
     }
 
     public int getDefaultAgentTimeout() {

--- a/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderLauncher.java
+++ b/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderLauncher.java
@@ -113,8 +113,8 @@ public class CodeBuilderLauncher extends JNLPLauncher {
     if (n == null) {
       return "";
     }
-    String cmd = String.format("jenkins-agent -noreconnect -workDir \"$CODEBUILD_SRC_DIR\" -url \"%s\" \"%s\" \"%s\"",
-        cloud.getJenkinsUrl(), computer.getJnlpMac(), n.getDisplayName());
+    String cmd = String.format("%s -noreconnect -workDir \"$CODEBUILD_SRC_DIR\" -url \"%s\" \"%s\" \"%s\"",
+        cloud.getJnlpCommand(), cloud.getJenkinsUrl(), computer.getJnlpMac(), n.getDisplayName());
     StringBuilder builder = new StringBuilder();
     builder.append("version: 0.2\n");
     builder.append("phases:\n");

--- a/src/main/resources/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud/config.jelly
+++ b/src/main/resources/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud/config.jelly
@@ -34,6 +34,10 @@
       <f:textbox default="${descriptor.defaultJnlpImage}" />
     </f:entry>
 
+    <f:entry field="jnlpCommand" title="${%JNLP Docker Image Command}">
+      <f:textbox default="${descriptor.defaultJnlpCommand}" />
+    </f:entry>
+
     <f:entry field="agentTimeout" title="${%Agent Connection Timeout}">
       <f:number default="${descriptor.defaultAgentTimeout}" />
     </f:entry>


### PR DESCRIPTION
I'm submitting this PR, as in our CI environment, the docker images are using the 'jenkins-slave' command instead of 'jenkins-agent' and rebuild the images will slow down the adoption of this plugin in our CI/CD environment. and maybe some other users may found this useful.

