### PR TITLE
missing select name cause computeType not saved

### DIFF
--- a/src/main/resources/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud/config.jelly
+++ b/src/main/resources/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud/config.jelly
@@ -18,7 +18,7 @@
   </f:entry>
 
   <f:entry field="computeType" title="${%Compute Type}">
-    <select>
+    <select name="computeType">
       <option value="BUILD_GENERAL1_SMALL">Small (2 vCPUs, 3GB RAM, 64GB Disk)</option>
       <option value="BUILD_GENERAL1_MEDIUM">Medium (4 vCPUs, 7GB RAM, 128GB Disk)</option>
       <option value="BUILD_GENERAL1_LARGE">Large (8 vCPUs, 15GB RAM, 128GB Disk)</option>

--- a/src/main/resources/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud/config.jelly
+++ b/src/main/resources/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud/config.jelly
@@ -19,9 +19,9 @@
 
   <f:entry field="computeType" title="${%Compute Type}">
     <select name="computeType">
-      <option value="BUILD_GENERAL1_SMALL">Small (2 vCPUs, 3GB RAM, 64GB Disk)</option>
-      <option value="BUILD_GENERAL1_MEDIUM">Medium (4 vCPUs, 7GB RAM, 128GB Disk)</option>
-      <option value="BUILD_GENERAL1_LARGE">Large (8 vCPUs, 15GB RAM, 128GB Disk)</option>
+      <option selected="${instance.computeType.equals('BUILD_GENERAL1_SMALL')? 'true':null}" value="BUILD_GENERAL1_SMALL">Small (2 vCPUs, 3GB RAM, 64GB Disk)</option>
+      <option selected="${instance.computeType.equals('BUILD_GENERAL1_MEDIUM')? 'true':null}" value="BUILD_GENERAL1_MEDIUM">Medium (4 vCPUs, 7GB RAM, 128GB Disk)</option>
+      <option selected="${instance.computeType.equals('BUILD_GENERAL1_LARGE')? 'true':null}" value="BUILD_GENERAL1_LARGE">Large (8 vCPUs, 15GB RAM, 128GB Disk)</option>
     </select>
   </f:entry>
 


### PR DESCRIPTION
the select for computeType is missing an attribute (name) , causing the configuration to be ignored.
