### PR TITLE
Custom buildspec.yaml

### DIFF
--- a/src/test/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloudTest.java
+++ b/src/test/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloudTest.java
@@ -13,7 +13,7 @@ public class CodeBuilderCloudTest {
 
   @Test
   public void initializes_correctly() throws InterruptedException {
-    CodeBuilderCloud cloud = new CodeBuilderCloud(null, "project", null, null);
+    CodeBuilderCloud cloud = new CodeBuilderCloud(null, "project", null, "local");
     assertEquals("project", cloud.getProjectName());
     assertEquals("codebuilder_0", cloud.getDisplayName());
     assertNotNull(cloud.getClient());


### PR DESCRIPTION
Allow for the possibility of a freestyle custom buildspec.

This would allow the user to create a project with his/her own `buildspec.yaml` file which would therefore allow for more freedom and flexibility in their builds, but at the same time be compatible with the codebuilder agent to build the project via jnlp.

For example, the user might have the following `buildspec.yaml` file:
```yaml
version: 0.2
phases:
  pre_build:
    commands:
      - which dockerd-entrypoint.sh >/dev/null && dockerd-entrypoint.sh || exit 0
  build:
    commands:
      - jenkins-agent -noreconnect -workDir "$CODEBUILD_SRC_DIR" -url "{{CODEBUILD_JENKINS_URL}}" "{{CODEBUILD_COMPUTER_JNLP_MAC}}" "{{CODEBUILD_NODE_DISPLAY_NAME}}"
      - exit 0
```

And what this PR does is simply replace the keywords `{{CODEBUILD_JENKINS_URL}}` `{{CODEBUILD_COMPUTER_JNLP_MAC}}` and `{{CODEBUILD_NODE_DISPLAY_NAME}}` with an override with the runtime values for the Codebuild jenkins URL, Computer JNLP MAC and Node's display name.

I got inspiration for this change when i needed to mount an NFS drive to cache maven dependencies and also be able to use Codebuild's own cache dir. More information on this use-case can be found [here](https://docs.amazonaws.cn/en_us/codebuild/latest/userguide/sample-efs.html).