### PR TITLE
Make default termination of agent optional, to reuse agent and speed up builds

### DIFF
--- a/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud.java
+++ b/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud.java
@@ -59,6 +59,7 @@ public class CodeBuilderCloud extends Cloud {
   private static final String DEFAULT_JNLP_IMAGE = "lsegal/jnlp-docker-agent:alpine";
   private static final int DEFAULT_AGENT_TIMEOUT = 120;
   private static final String DEFAULT_COMPUTE_TYPE = "BUILD_GENERAL1_SMALL";
+  private static final boolean DEFAULT_TERMINATE_AGENT = true;
 
   static {
     clearAllNodes();

--- a/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud.java
+++ b/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud.java
@@ -78,6 +78,7 @@ public class CodeBuilderCloud extends Cloud {
   private String jenkinsUrl;
   private String jnlpImage;
   private int agentTimeout;
+  private boolean terminateAgent;
 
   private transient AWSCodeBuild client;
 
@@ -389,6 +390,14 @@ public class CodeBuilderCloud extends Cloud {
     }
   }
 
+  public boolean isTerminateAgent() {
+    return terminateAgent;
+  }
+  
+  public void setTerminateAgent(boolean terminateAgent) {
+    this.terminateAgent = terminateAgent;
+  }
+    
   @Extension
   public static class DescriptorImpl extends Descriptor<Cloud> {
     @Override
@@ -406,6 +415,10 @@ public class CodeBuilderCloud extends Cloud {
 
     public String getDefaultComputeType() {
       return DEFAULT_COMPUTE_TYPE;
+    }
+
+    public boolean getDefaultTerminateAgent() {
+    	return DEFAULT_TERMINATE_AGENT;
     }
 
     public ListBoxModel doFillCredentialsIdItems() {

--- a/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud.java
+++ b/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud.java
@@ -378,8 +378,14 @@ public class CodeBuilderCloud extends Cloud {
   /** {@inheritDoc} */
   @Override
   public boolean canProvision(Label label) {
+    LOGGER.info("[CodeBuilder]: Check if can provision node for label '{}'", label);
     boolean canProvision = label == null ? true : label.matches(Arrays.asList(new LabelAtom(getLabel())));
-    LOGGER.info("[CodeBuilder]: Check provisioning capabilities for label '{}': {}", label, canProvision);
+    if (canProvision) {
+      LOGGER.info("[CodeBuilder]: Label '{}' matches current label '{}'. Node will be provisioned...", label, getLabel());
+    }
+    else {
+      LOGGER.info("[CodeBuilder]: Label '{}' DOESN'T MATCH current label '{}'. Node WON'T provisioned...", label, getLabel());
+    }
     return canProvision;
   }
 

--- a/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud.java
+++ b/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud.java
@@ -329,7 +329,8 @@ public class CodeBuilderCloud extends Cloud {
   @Override
   public synchronized Collection<PlannedNode> provision(Label label, int excessWorkload) {
     List<NodeProvisioner.PlannedNode> list = new ArrayList<NodeProvisioner.PlannedNode>();
-
+    String labelName = label == null ? getLabel() : label.getDisplayName();
+    LOGGER.info("[CodeBuilder]: Excess workload sent by Jenkins: {} for label: {}", excessWorkload, labelName);
     // guard against non-matching labels
     if (label != null && !label.matches(Arrays.asList(new LabelAtom(getLabel())))) {
       return list;
@@ -343,7 +344,6 @@ public class CodeBuilderCloud extends Cloud {
       return list;
     }
 
-    String labelName = label == null ? getLabel() : label.getDisplayName();
     long stillProvisioning = numStillProvisioning();
     long numToLaunch = Math.max(excessWorkload - stillProvisioning, 0);
     LOGGER.info("[CodeBuilder]: Provisioning {} nodes for label '{}' ({} already provisioning)", numToLaunch, labelName,
@@ -372,7 +372,7 @@ public class CodeBuilderCloud extends Cloud {
    */
   private long numStillProvisioning() {
     return jenkins().getNodes().stream().filter(CodeBuilderAgent.class::isInstance).map(CodeBuilderAgent.class::cast)
-        .filter(a -> a.getLauncher().isLaunchSupported()).count();
+        .filter(a -> !a.getLauncher().isLaunchSupported()).count();
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderComputer.java
+++ b/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderComputer.java
@@ -77,7 +77,9 @@ public class CodeBuilderComputer extends AbstractCloudComputer<CodeBuilderAgent>
   public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
     super.taskCompleted(executor, task, durationMS);
     LOGGER.info("[CodeBuilder]: [{}]: Task in job '{}' completed in {}ms", this, task.getFullDisplayName(), durationMS);
-    gracefulShutdown();
+    if (cloud.isTerminateAgent()) {
+    	gracefulShutdown();
+    }
   }
 
   /** {@inheritDoc} */
@@ -86,7 +88,9 @@ public class CodeBuilderComputer extends AbstractCloudComputer<CodeBuilderAgent>
     super.taskCompletedWithProblems(executor, task, durationMS, problems);
     LOGGER.error("[CodeBuilder]: [{}]: Task in job '{}' completed with problems in {}ms", this,
         task.getFullDisplayName(), durationMS, problems);
-    gracefulShutdown();
+    if (cloud.isTerminateAgent()) {
+      gracefulShutdown();
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderLauncher.java
+++ b/src/main/java/dev/lsegal/jenkins/codebuilder/CodeBuilderLauncher.java
@@ -66,7 +66,7 @@ public class CodeBuilderLauncher extends JNLPLauncher {
     CodeBuilderComputer cbcpu = (CodeBuilderComputer) computer;
     StartBuildRequest req = new StartBuildRequest().withProjectName(cloud.getProjectName())
         .withSourceTypeOverride(SourceType.NO_SOURCE).withBuildspecOverride(buildspec(computer))
-        .withImageOverride(cloud.getJnlpImage()).withPrivilegedModeOverride(true)
+        .withImageOverride(cloud.getJnlpImage()).withPrivilegedModeOverride(true).withTimeoutInMinutesOverride(480)
         .withComputeTypeOverride(cloud.getComputeType());
 
     try {

--- a/src/main/resources/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud/config.jelly
+++ b/src/main/resources/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud/config.jelly
@@ -37,5 +37,9 @@
     <f:entry field="agentTimeout" title="${%Agent Connection Timeout}">
       <f:number default="${descriptor.defaultAgentTimeout}" />
     </f:entry>
+
+    <f:entry field="terminateAgent" title="${%Terminate Agent After Task completion}">
+      <f:checkbox default="${descriptor.defaultTerminateAgent}"/>
+    </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud/help-agentTimeout.html
+++ b/src/main/resources/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud/help-agentTimeout.html
@@ -1,4 +1,6 @@
 <p>
   The time in seconds to wait before giving up on an agent connection. Default
-  value is 120 seconds.
+  value is 120 seconds. If you are using a load balancer its idle connection timeout
+  should be the same.
+  Maximum value is the same as configured in the codebuild project.
 </p>

--- a/src/main/resources/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud/help-terminateAgent.html
+++ b/src/main/resources/dev/lsegal/jenkins/codebuilder/CodeBuilderCloud/help-terminateAgent.html
@@ -1,0 +1,7 @@
+<p>Determines whether to terminate the codebuild Agent after the task is finished.</p>
+<p>
+  After a task is finished default behavior is to terminate the codebuild agent
+  right after the build is finished. By disabling this option the codebuild agent 
+  will run for the amount of time specified by the Agent Connection Timeout. Each new build
+  will extend the Agent runtime for the Agent Connection Timeout value.
+</p>

--- a/src/test/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloudTest.java
+++ b/src/test/java/dev/lsegal/jenkins/codebuilder/CodeBuilderCloudTest.java
@@ -13,7 +13,7 @@ public class CodeBuilderCloudTest {
 
   @Test
   public void initializes_correctly() throws InterruptedException {
-    CodeBuilderCloud cloud = new CodeBuilderCloud(null, "project", null, null);
+    CodeBuilderCloud cloud = new CodeBuilderCloud(null, "project", null, "eu-west-1");
     assertEquals("project", cloud.getProjectName());
     assertEquals("codebuilder_0", cloud.getDisplayName());
     assertNotNull(cloud.getClient());


### PR DESCRIPTION
We added a new field in the Cloud configuration to select the termination of the CodeBuild agent after a build. By not terminating the agent, Jenkins can reuse the node and new builds start immediately. We experienced that builds sometimes waste about two minutes by spinning up an agent. The Agent Connection Timeout specifies how long the agent will stay alive. This value also needs to be set in a load balancer, if that is configured.